### PR TITLE
feature/single precision (ESMF init errors)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = ssh://git@github.com/SamuelTrahanNOAA/ccpp-physics
-  branch = sing_prec_from_main
+  #url = ssh://git@github.com/SamuelTrahanNOAA/ccpp-physics
+  #branch = sing_prec_from_main
+  url = https://github.com/climbfuji/ccpp-physics
+  branch = feature/single_precision
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1244,7 +1244,22 @@ subroutine update_atmos_chemistry(state, rc)
   integer :: ni, nj, nk, nt, ntb, nte
   integer :: nb, ix, i, j, k, k1, it
   integer :: ib, jb
+#ifdef CCPP_32BIT
+  real(ESMF_KIND_R4), dimension(:,:,:),   pointer :: cldfra,       &
+                                                     pfils, pflls, &
+                                                     phii,  phil,  &
+                                                     prsi,  prsl,  &
+                                                     slc,   smc,   &
+                                                     stc,   temp,  &
+                                                     ua,    va
 
+  real(ESMF_KIND_R4), dimension(:,:,:,:), pointer :: q
+
+  real(ESMF_KIND_R4), dimension(:,:), pointer :: aod, area, canopy, cmm,  &
+    dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, nswsfc, oro, psfc, &
+    q2m, rain, rainc, rca, shfsfc, slmsk, stype, swet, t2m, tsfc,    &
+    u10m, uustar, v10m, vfrac, xlai, zorl
+#else
   real(ESMF_KIND_R8), dimension(:,:,:),   pointer :: cldfra,       &
                                                      pfils, pflls, &
                                                      phii,  phil,  &
@@ -1259,7 +1274,7 @@ subroutine update_atmos_chemistry(state, rc)
     dqsfc, dtsfc, fice, flake, focn, fsnow, hpbl, nswsfc, oro, psfc, &
     q2m, rain, rainc, rca, shfsfc, slmsk, stype, swet, t2m, tsfc,    &
     u10m, uustar, v10m, vfrac, xlai, zorl
-
+#endif
 ! logical, parameter :: diag = .true.
 
   ! -- begin
@@ -2731,6 +2746,10 @@ end subroutine update_atmos_chemistry
 
     do n=1, size(exportFields)
 
+      ! DH*
+      write(0,'(a,i6)') "XXX1: DH DEBUG: loop through exportFields, n=", n
+      ! *DH
+
       datar42d => null()
       datar82d => null()
       datar83d => null()
@@ -2779,7 +2798,6 @@ end subroutine update_atmos_chemistry
             ! Instantaneous u wind (m/s) 10 m above ground
             case ('inst_zonal_wind_height10m')
               call block_data_copy(datar82d, GFS_data(nb)%coupling%u10mi_cpl, Atm_block, nb, rc=localrc)
-              !call block_data_copy(datar82d, GFS_data(nb)%coupling%u10mi_cpl, Atm_block, nb, rc=localrc)
             ! Instantaneous v wind (m/s) 10 m above ground
             case ('inst_merid_wind_height10m')
               call block_data_copy(datar82d, GFS_data(nb)%coupling%v10mi_cpl, Atm_block, nb, rc=localrc)

--- a/module_fcst_grid_comp.F90
+++ b/module_fcst_grid_comp.F90
@@ -74,7 +74,6 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
   use module_cplfields,       only: realizeConnectedCplFields
 
   use atmos_model_mod,        only: setup_exportdata
-  use CCPP_data,              only: GFS_control
 !
 !-----------------------------------------------------------------------
 !
@@ -444,10 +443,17 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     call ESMF_GridCompGet(nest, grid=grid, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,  file=__FILE__)) return
 
+    ! DH*
+    write(0,'(a)') "YYY: BEFORE realizeConnectedCplFields(exportState ..."
+    ! *DH
     ! -- realize connected fields in exportState
     call realizeConnectedCplFields(exportState, grid, &
                                    numLevels, numSoilLayers, numTracers, &
+#ifdef CCPP_32BIT
+                                   exportFieldsInfo, 'FV3 Export', exportFields, 0.0_ESMF_KIND_R4, rc)
+#else
                                    exportFieldsInfo, 'FV3 Export', exportFields, 0.0_ESMF_KIND_R8, rc)
+#endif
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,  file=__FILE__)) return
 
     ! -- initialize export fields if applicable
@@ -457,7 +463,11 @@ if (rc /= ESMF_SUCCESS) write(0,*) 'rc=',rc,__FILE__,__LINE__; if(ESMF_LogFoundE
     ! -- realize connected fields in importState
     call realizeConnectedCplFields(importState, grid, &
                                    numLevels, numSoilLayers, numTracers, &
+#ifdef CCPP_32BIT
+                                   importFieldsInfo, 'FV3 Import', importFields, 9.99e20_ESMF_KIND_R4, rc)
+#else
                                    importFieldsInfo, 'FV3 Import', importFields, 9.99e20_ESMF_KIND_R8, rc)
+#endif
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__,  file=__FILE__)) return
 !
 !-----------------------------------------------------------------------


### PR DESCRIPTION
### WORK IN PROGRESS

- A fool's attempt to fix ESMF init crash due to incompatible floating point kinds
- Waiting on https://github.com/earth-system-radiation/rte-rrtmgp/pull/171
- Waiting on https://github.com/SamuelTrahanNOAA/ccpp-physics/pull/3

Note. The current code in @SamuelTrahanNOAA's branches (recursive clone of branch `sing_prec_from_main` of the ufs-weather-model, see PR https://github.com/ufs-community/ufs-weather-model/pull/1215) crashes in the model initialization step, but not in the physics - it crashes deep inside the ESMF grid/field initialization (cont'd below):
```
20220522 105805.131 INFO             PET134 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
20220522 105805.131 INFO             PET134 !!! THE ESMF_LOG IS SET TO OUTPUT ALL LOG MESSAGES !!!
20220522 105805.131 INFO             PET134 !!!     THIS MAY CAUSE SLOWDOWN IN PERFORMANCE     !!!
20220522 105805.131 INFO             PET134 !!! FOR PRODUCTION RUNS, USE:                      !!!
20220522 105805.131 INFO             PET134 !!!                   ESMF_LOGKIND_Multi_On_Error  !!!
20220522 105805.131 INFO             PET134 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
20220522 105805.131 INFO             PET134 Running with ESMF Version   : v8.3.0b09
20220522 105805.131 INFO             PET134 ESMF library build date/time: "Mar 29 2022" "17:20:36"
20220522 105805.131 INFO             PET134 ESMF library build location : /glade/work/jongkim/stacks/hash/hpc-stack-esmf/pkg/v8.3.0b09
20220522 105805.131 INFO             PET134 ESMF_COMM                   : mpt
20220522 105805.131 INFO             PET134 ESMF_MOAB                   : enabled
20220522 105805.131 INFO             PET134 ESMF_LAPACK                 : enabled
20220522 105805.131 INFO             PET134 ESMF_NETCDF                 : enabled
20220522 105805.131 INFO             PET134 ESMF_PNETCDF                : disabled
20220522 105805.131 INFO             PET134 ESMF_PIO                    : enabled
20220522 105805.131 INFO             PET134 ESMF_YAMLCPP                : enabled
20220522 105805.132 TRACE            PET134  ESMF_LogSet() !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
20220522 105805.132 TRACE            PET134  ESMF_LogSet() !!!       TRACING is disabled         !!!
20220522 105805.132 TRACE            PET134  ESMF_LogSet() !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
20220522 105805.394 INFO             PET134 ReadAttributes DRIVER_attributes:: start:
20220522 105805.394 INFO             PET134 ReadAttributes DRIVER_attributes:: end:
20220522 105805.394 INFO             PET134 ReadAttributes ALLCOMP_attributes:: start:
20220522 105805.394 INFO             PET134 ReadAttributes ALLCOMP_attributes:: end:
20220522 105805.394 INFO             PET134 (module_EARTH_GRID_COMP.F90:InitRestart): called
20220522 105805.394 INFO             PET134 No start_type attribute found, setting read_restart false
20220522 105805.394 INFO             PET134 Set attribute read_restart in driver
20220522 105805.400 INFO             PET134 (module_EARTH_GRID_COMP.F90:AddAttributes): called
20220522 105805.400 INFO             PET134 Added attribute read_restart to ATM
20220522 105805.400 INFO             PET134 ReadAttributes ATM_attributes:: start:
20220522 105805.400 INFO             PET134 ReadAttributes ATM_attributes:: end:
20220522 105805.400 INFO             PET134 ReadAttributes ATM_modelio:: start:
20220522 105805.400 INFO             PET134 ReadAttributes ATM_modelio:: end:
20220522 105805.400 INFO             PET134 ReadAttributes ALLCOMP_attributes:: start:
20220522 105805.400 INFO             PET134 ReadAttributes ALLCOMP_attributes:: end:
20220522 105805.424 INFO             PET134 (fv3_cap:InitializeAdvertise) cplprint_flag =      F
20220522 105805.424 INFO             PET134 (fv3_cap:InitializeAdvertise) dbug =      0
20220522 105805.427 DEBUG            PET134 Generic SetVM() is executing for: fv3_fcst
20220522 105805.427 DEBUG            PET134 Generic SetVM() found no NUOPC Hint for: fv3_fcst
20220522 105805.427 DEBUG            PET134 Generic SetVM() therefore is NOT calling ESMF_GridCompSetVMMaxPEs() for: fv3_fcst
20220522 105836.613 ERROR            PET134 ESMCI_Grid.C:3685 ESMCI::Grid::setCoordArray() Arguments are incompatible  - - Array and Grid TypeKind mismatch
20220522 105836.614 ERROR            PET134 ESMCI_Grid_F.C:1091 c_esmc_gridsetfromarray() Arguments are incompatible  - Internal subroutine call returned Error
20220522 105836.614 ERROR            PET134 ESMF_Grid.F90:25269 ESMF_GridSetCoordFromArray Arguments are incompatible  - Internal subroutine call returned Error
20220522 105836.617 ERROR            PET134 /glade/work/heinzell/fv3/ufs-weather-model/ufs-weather-model-rap-control-32bit/gnu/FV3/module_fcst_grid_comp.F90:233 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 /glade/work/heinzell/fv3/ufs-weather-model/ufs-weather-model-rap-control-32bit/gnu/FV3/module_fcst_grid_comp.F90:837 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 /glade/work/heinzell/fv3/ufs-weather-model/ufs-weather-model-rap-control-32bit/gnu/FV3/fv3_cap.F90:377 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 ATM:src/addon/NUOPC/src/NUOPC_ModelBase.F90:700 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 EARTH Grid Comp:src/addon/NUOPC/src/NUOPC_Driver.F90:2577 Arguments are incompatible  - Phase 'IPDvXp01' Initialize for modelComp 1: ATM did not return ESMF_SUCCESS
20220522 105836.617 ERROR            PET134 EARTH Grid Comp:src/addon/NUOPC/src/NUOPC_Driver.F90:1286 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 EARTH Grid Comp:src/addon/NUOPC/src/NUOPC_Driver.F90:457 Arguments are incompatible  - Passing error in return code
20220522 105836.617 ERROR            PET134 /glade/work/heinzell/fv3/ufs-weather-model/ufs-weather-model-rap-control-32bit/gnu/driver/UFS.F90:386 Arguments are incompatible  - Aborting UFS
20220522 105836.617 INFO             PET134 Finalizing ESMF
```
This PR is a fool's attempt from someone with no idea of ESMF and how the coupling is realized to make this work. But it doesn't, still the same error. I actually believe that it would be better to improve the interface between the physics fields and the coupling fields, so that:
- Physics use their own variables in the precision requested for physics
- Coupling fields are what the coupling framework in the host model defines (double precision in the UFS?)
- Physics fields are updated from coupling fields and vice versa *outside* of the physics. Right now, coupling fields are passed to the physics, and the physics are required to "know" which arrays to populate based on a few logical flags. This seems wrong to me, there should be a separation of concerns?